### PR TITLE
Fix for manual installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ git clone https://github.com/aodhneine/horizon-theme.el
 and then add the following lines to your init file:
 
 ``` emacs-lisp
-(add-to-list 'load-path "path/to/horizon/theme/")
+(add-to-list 'custom-theme-load-path "path/to/horizon/theme/")
 (load-theme 'horizon t)
 ```
 


### PR DESCRIPTION
Unfortunately, `load-path` didn't work for me, `custom-theme-load-path` did tho. Probably not that important once this is available on MELPA, but still decided to submit a PR.

My Emacs version is 26.3