### PR TITLE
fix: make horizon-theme more discoverable

### DIFF
--- a/horizon-theme.el
+++ b/horizon-theme.el
@@ -194,6 +194,12 @@ influence of C1 on the result."
    `(evil-ex-substitute-matches ((t :foreground ,red :strike-through t)))
    `(evil-ex-substitute-replacement ((t :foreground ,green)))))
 
+;;;###autoload
+(when load-file-name
+  (add-to-list 'custom-theme-load-path
+               (file-name-as-directory (file-name-directory load-file-name))))
+
+(provide-theme 'horizon)
 
 (provide 'horizon-theme)
 


### PR DESCRIPTION
Hello! I maintain [PeachMelpa](https://peach-melpa.org) and was wondering why this beautiful theme wasn't showing up. Turns out it's not discoverable in `(custom-available-themes)` which PeachMelpa relies on to discover new themes.

I looked over and [found the relevant lines in the Modus themes](https://gitlab.com/protesilaos/modus-themes/-/blob/master/modus-operandi-theme.el#L3920). They make the theme visible in `(custom-available-themes)`. You do advise editing the `custom-theme-load-path` in the README, but only for people who want to install the theme manually so maybe you've already thought about it.

Anyway, here's the commit message:
```
Adding to `custom-theme-load-path` and using `provide-theme` means the
theme can now be loaded with `(load-theme 'horizon)` rather than
invoking `(use-package 'horizon)`.
```